### PR TITLE
move DisableWidgets from Specialize to DefaultUser

### DIFF
--- a/modifier/Optimizations.cs
+++ b/modifier/Optimizations.cs
@@ -221,7 +221,7 @@ class OptimizationsModifier(ModifierContext context) : Modifier(context)
 
     if (Configuration.DisableWidgets)
     {
-      UserOnceScript.Append(@"New-ItemProperty 'HKLM:\Default\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced' -Name 'TaskbarDa' -Value '0' -PropertyType Dword -Force;");
+      DefaultUserScript.Append(@$"reg.exe add ""HKU\DefaultUser\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced"" /v TaskbarDa /t REG_DWORD /d 0 /f;");
     }
 
     if (Configuration.TurnOffSystemSounds)

--- a/modifier/Optimizations.cs
+++ b/modifier/Optimizations.cs
@@ -221,7 +221,7 @@ class OptimizationsModifier(ModifierContext context) : Modifier(context)
 
     if (Configuration.DisableWidgets)
     {
-      SpecializeScript.Append(@"reg.exe add ""HKLM\SOFTWARE\Policies\Microsoft\Dsh"" /v AllowNewsAndInterests /t REG_DWORD /d 0 /f;");
+      UserOnceScript.Append(@"Set-ItemProperty -LiteralPath 'Registry::HKCU\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced' -Name 'TaskbarDa' -Type 'DWord' -Value 0;");
     }
 
     if (Configuration.TurnOffSystemSounds)

--- a/modifier/Optimizations.cs
+++ b/modifier/Optimizations.cs
@@ -221,7 +221,7 @@ class OptimizationsModifier(ModifierContext context) : Modifier(context)
 
     if (Configuration.DisableWidgets)
     {
-      UserOnceScript.Append(@"Set-ItemProperty -LiteralPath 'Registry::HKCU\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced' -Name 'TaskbarDa' -Type 'DWord' -Value 0;");
+      DefaultUserScript.Append(@$"reg.exe add ""HKU\DefaultUser\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced"" /v TaskbarDa /t REG_DWORD /d 0 /f;");
     }
 
     if (Configuration.TurnOffSystemSounds)

--- a/modifier/Optimizations.cs
+++ b/modifier/Optimizations.cs
@@ -221,7 +221,7 @@ class OptimizationsModifier(ModifierContext context) : Modifier(context)
 
     if (Configuration.DisableWidgets)
     {
-      DefaultUserScript.Append(@$"reg.exe add ""HKU\DefaultUser\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced"" /v TaskbarDa /t REG_DWORD /d 0 /f;");
+      UserOnceScript.Append(@"Set-ItemProperty -LiteralPath 'Registry::HKCU\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced' -Name 'TaskbarDa' -Type 'DWord' -Value 0 -Force;");
     }
 
     if (Configuration.TurnOffSystemSounds)

--- a/modifier/Optimizations.cs
+++ b/modifier/Optimizations.cs
@@ -221,7 +221,7 @@ class OptimizationsModifier(ModifierContext context) : Modifier(context)
 
     if (Configuration.DisableWidgets)
     {
-      UserOnceScript.Append(@"Set-ItemProperty -LiteralPath 'Registry::HKCU\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced' -Name 'TaskbarDa' -Type 'DWord' -Value 0 -Force;");
+      UserOnceScript.Append(@"New-ItemProperty 'HKLM:\Default\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced' -Name 'TaskbarDa' -Value '0' -PropertyType Dword -Force;");
     }
 
     if (Configuration.TurnOffSystemSounds)


### PR DESCRIPTION
This prevents the "Some settings are managed by your administrator" banner in the Settings page for Taskbar customization, while still being able to disable the Widgets.

Additionally, this also lets users enable it later by simply flipping the toggle in the Settings instead of digging into the registry stuff.

_In short, it flips the "Widgets" toggle in Taskbar settings off instead of locking it behind a policy._