### PR TITLE
Improve the way computer name is set

### DIFF
--- a/resource/SetComputerName.ps1
+++ b/resource/SetComputerName.ps1
@@ -2,15 +2,26 @@ $ErrorActionPreference = 'Stop';
 Set-StrictMode -Version 'Latest';
 & {
 	$newName = ( Get-Content -LiteralPath 'C:\Windows\Setup\Scripts\ComputerName.txt' -Raw ).Trim();
+	$newComputerName = $newName.toUpper()
+	if (($newComputerName.Length) -gt 15) {
+		$newComputerName = $newComputerName.Substring(0, 15)
+	}
 	if( [string]::IsNullOrWhitespace( $newName ) ) {
 		throw "No computer name was provided.";
 	}
 
+	$keys_activename = @(
+			   @{
+				LiteralPath = 'Registry::HKLM\SYSTEM\CurrentControlSet\Control\ComputerName\ActiveComputerName';
+				Name = 'ComputerName';
+			   };
+			   @{
+				LiteralPath = 'Registry::HKLM\SYSTEM\CurrentControlSet\Control\ComputerName\ComputerName';
+				Name = 'ComputerName';
+			   };
+	);
+
 	$keys = @(
-		@{
-			LiteralPath = 'Registry::HKLM\SYSTEM\CurrentControlSet\Control\ComputerName\ComputerName';
-			Name = 'ComputerName';
-		};
 		@{
 			LiteralPath = 'Registry::HKLM\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters';
 			Name = 'Hostname';
@@ -22,6 +33,9 @@ Set-StrictMode -Version 'Latest';
 	);
 
 	while( $true ) {
+		foreach( $key in $keys_activename ) {
+			Set-ItemProperty @key -Type 'String' -Value $newComputerName;
+		}
 		foreach( $key in $keys ) {
 			Set-ItemProperty @key -Type 'String' -Value $newName;
 		}


### PR DESCRIPTION
ActiveComputerName and ComputerName keys require NetBIOS compliance. Violation of it will cause BSoD with CRITICAL_PROCESS_DIED. However, Tcpip parameters "Hostname" and "NV Hostname" are fine with names longer than what NetBIOS requires. These are the keys local Windows apps like Settings and the "hostname" command in CMD read from, too.

Also adds "ActiveComputerName" key along so that we do it the way Windows itself does it when the user sets the hostname themselves. This won't impact future (manual) hostname changes done through Settings.

A script I made to test this: https://github.com/kurtbahartr/windows-configs/blob/0dd55d66ce1bf1b1271d2fa11dc403ab31bac4af/autounattend.xml#L124-L127

Recommended environment to test on: VMware Workstation Virtual Machine with Windows 10/11.