### PR TITLE
Improve Edge disable startup boost option

### DIFF
--- a/modifier/Optimizations.cs
+++ b/modifier/Optimizations.cs
@@ -428,6 +428,7 @@ class OptimizationsModifier(ModifierContext context) : Modifier(context)
 
     if (Configuration.DisableEdgeStartupBoost)
     {
+      SpecializeScript.Append(@"reg.exe add ""HKLM\Software\Policies\Microsoft\Edge\Recommended"" /v BackgroundModeEnabled /t REG_DWORD /d 0 /f;");
       SpecializeScript.Append(@"reg.exe add ""HKLM\Software\Policies\Microsoft\Edge\Recommended"" /v StartupBoostEnabled /t REG_DWORD /d 0 /f;");
     }
 

--- a/modifier/Optimizations.cs
+++ b/modifier/Optimizations.cs
@@ -428,7 +428,7 @@ class OptimizationsModifier(ModifierContext context) : Modifier(context)
 
     if (Configuration.DisableEdgeStartupBoost)
     {
-      SpecializeScript.Append(@"reg.exe add ""HKLM\Software\Policies\Microsoft\Edge"" /v StartupBoostEnabled /t REG_DWORD /d 0 /f;");
+      SpecializeScript.Append(@"reg.exe add ""HKLM\Software\Policies\Microsoft\Edge\Recommended"" /v StartupBoostEnabled /t REG_DWORD /d 0 /f;");
     }
 
     {


### PR DESCRIPTION
This PR does the following:
- Moves the `StartupBoostEnabled` registry under the `Recommended` subkey. This defaults the option to false rather than disabling it outright, allowing it to still be configured by the user.
- Set the `BackgroundModeEnabled` registry value to false, which toggles if background extensions can run when the browser is closed. It is also added under the `Recommended` subkey.