### PR TITLE
Re-add `New > Text Document` context menu item if modern Notepad is uninstalled

### DIFF
--- a/modifier/Bloatware.cs
+++ b/modifier/Bloatware.cs
@@ -185,6 +185,10 @@ class BloatwareModifier(ModifierContext context) : Modifier(context)
             SpecializeScript.Append(@"reg.exe add ""HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Communications"" /v ConfigureChatAutoInstall /t REG_DWORD /d 0 /f;");
             break;
           case CustomBloatwareStep when bw.Id == "RemoveNotepad":
+            SpecializeScript.Append("""
+              reg.exe add "HKCR\.txt\ShellNew" /v NullFile /t REG_SZ /d "" /f;
+              reg.exe add "HKCR\txtfilelegacy" /ve /t REG_SZ /d "Text Document" /f;
+              """);
             DefaultUserScript.Append(@$"reg.exe add ""HKU\DefaultUser\Software\Microsoft\Notepad"" /v ShowStoreBanner /t REG_DWORD /d 0 /f;");
             break;
           case CustomBloatwareStep when bw.Id == "RemoveOutlook":

--- a/modifier/Bloatware.cs
+++ b/modifier/Bloatware.cs
@@ -186,7 +186,9 @@ class BloatwareModifier(ModifierContext context) : Modifier(context)
             break;
           case CustomBloatwareStep when bw.Id == "RemoveNotepad":
             SpecializeScript.Append("""
+              reg.exe add "HKCR\.txt\ShellNew" /v ItemName /t REG_EXPAND_SZ /d "@C:\Windows\system32\notepad.exe,-470" /f;
               reg.exe add "HKCR\.txt\ShellNew" /v NullFile /t REG_SZ /d "" /f;
+              reg.exe add "HKCR\txtfilelegacy" /v FriendlyTypeName /t REG_EXPAND_SZ /d "@C:\Windows\system32\notepad.exe,-469" /f;
               reg.exe add "HKCR\txtfilelegacy" /ve /t REG_SZ /d "Text Document" /f;
               """);
             DefaultUserScript.Append(@$"reg.exe add ""HKU\DefaultUser\Software\Microsoft\Notepad"" /v ShowStoreBanner /t REG_DWORD /d 0 /f;");


### PR DESCRIPTION
With this PR, the script will now re-add the registry keys and values to restore right-click context menu support for new text documents when modern Notepad is uninstalled.