### PR TITLE
Disable Snipping Tool keyboard shortcuts if app is uninstalled

### DIFF
--- a/modifier/Bloatware.cs
+++ b/modifier/Bloatware.cs
@@ -200,6 +200,12 @@ class BloatwareModifier(ModifierContext context) : Modifier(context)
           case CustomBloatwareStep when bw.Id == "RemoveXboxApps":
             DefaultUserScript.Append(@$"reg.exe add ""HKU\DefaultUser\Software\Microsoft\Windows\CurrentVersion\GameDVR"" /v AppCaptureEnabled /t REG_DWORD /d 0 /f;");
             break;
+          case CustomBloatwareStep when bw.Id == "RemoveSnippingTool":
+            DefaultUserScript.Append("""
+              reg.exe add "HKU\DefaultUser\Control Panel\Keyboard" /v PrintScreenKeyForSnippingEnabled /t REG_DWORD /d 0 /f;
+              reg.exe add "HKU\DefaultUser\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced" /v DisabledHotkeys /t REG_SZ /d "RS" /f;
+              """);
+            break;
           default:
             throw new NotSupportedException();
         }


### PR DESCRIPTION
When the Snipping Tool app is uninstalled, the [associated keyboard shortcuts](https://support.microsoft.com/en-us/windows/use-snipping-tool-to-capture-screenshots-00246869-1843-655f-f220-97299b865f6b#id0edd=windows_11) (`Win + Shift + R`, `Win + Shift + S`, and `PrtSc`) still trigger a "zombie" version of the screen capture function that doesn't save anything captured. This is a [known issue](https://techbits.io/remove-snipping-tool-as-default-windows-screenshot-tool/) with Windows 10/11, and it can be mitigated by disabling the keybinds entirely with the registry entries added by this PR.