### PR TITLE
Add missing registry values to disable Content Delivery Manager option

### DIFF
--- a/modifier/Optimizations.cs
+++ b/modifier/Optimizations.cs
@@ -408,6 +408,8 @@ class OptimizationsModifier(ModifierContext context) : Modifier(context)
           'SubscribedContent-338388Enabled';
           'SubscribedContent-338389Enabled';
           'SubscribedContent-338393Enabled';
+          'SubscribedContent-353694Enabled';
+          'SubscribedContent-353696Enabled';
           'SubscribedContent-353698Enabled';
           'SystemPaneSuggestionsEnabled';
         );

--- a/modifier/Optimizations.cs
+++ b/modifier/Optimizations.cs
@@ -391,7 +391,7 @@ class OptimizationsModifier(ModifierContext context) : Modifier(context)
 
     if (Configuration.DisableAppSuggestions)
     {
-      // https://skanthak.homepage.t-online.de/ten.html#eighth
+      // https://skanthak.hier-im-netz.de/ten.html#eight
 
       DefaultUserScript.Append("""
         $names = @(


### PR DESCRIPTION
This PR adds [two missing registry values](https://www.elevenforum.com/t/enable-or-disable-suggested-content-in-settings-in-windows-11.3791/#Two) (`SubscribedContent-353694Enabled`, `SubscribedContent-353696Enabled`) to the "Disable app suggestions / Content Delivery Manager" option, effectively disabling the "Show me suggested content in the Settings app" setting under `Privacy & Security > General`. It was previously showing as enabled due to these missing values.

<img width="1531" height="119" alt="image" src="https://github.com/user-attachments/assets/1e236c63-13f5-4786-9578-e90bf759a691" />