### PR TITLE
Fix start menu pins not working on 26200.8521 and newer

### DIFF
--- a/resource/SetStartPins.ps1
+++ b/resource/SetStartPins.ps1
@@ -4,3 +4,4 @@ if( [System.Environment]::OSVersion.Version.Build -lt 20000 ) {
 $key = 'Registry::HKLM\SOFTWARE\Microsoft\PolicyManager\current\device\Start';
 New-Item -Path $key -ItemType 'Directory' -ErrorAction 'SilentlyContinue';
 Set-ItemProperty -LiteralPath $key -Name 'ConfigureStartPins' -Value $json -Type 'String';
+Set-ItemProperty -LiteralPath $key -Name 'ConfigureStartPins_ProviderSet' -Value 1 -Type 'DWord';


### PR DESCRIPTION
@cschneegans 26200.8521 brought some changes to the start menu (removed the classic start menu) and the unattend file is currently unable to modify the start pins. With this fix it will work again.